### PR TITLE
added compatibility with esp-idf ver5 and latest MicroPython

### DIFF
--- a/st7789/png/pngle.c
+++ b/st7789/png/pngle.c
@@ -42,7 +42,7 @@
 #include "py/runtime.h"
 #include "py/builtin.h"
 #include "py/mphal.h"
-#include "extmod/machine_spi.h"
+#include "extmod/modmachine.h"
 #include "mpfile.h"
 
 #include "st7789.h"

--- a/st7789/st7789.c
+++ b/st7789/st7789.c
@@ -32,6 +32,7 @@
 #include <math.h>
 #include <stdio.h>
 #include <string.h>
+#include "hal/gpio_ll.h"
 #include "driver/dedic_gpio.h"
 #include "driver/gpio.h"
 
@@ -41,7 +42,7 @@
 #include "py/runtime.h"
 #include "py/builtin.h"
 #include "py/mphal.h"
-#include "extmod/machine_spi.h"
+#include "extmod/modmachine.h"
 
 #include "mpfile.h"
 #include "st7789.h"


### PR DESCRIPTION
Recently MicroPython has moved some things into `modmachine.h` and this project still relies on `machine_spi.h`.
Moreover ESP-IDF ver5 has broken the reference to `GPIO` because it's not part of the public API anyway.
On this issue I found suggestion to include `hal/gpio_ll.h` but while fixing the build it is still prone to breakage in case they move things around again.
https://github.com/espressif/esp-idf/issues/9184

I have yet to test this, but I managed to make it build on ESP-IDF ver5 and the latest main on MicroPython.

Goes without saying that these changes will break builds on older version of MicroPython using IDF ver 4.x

